### PR TITLE
fixed inverted pokeball and prev/next button bugs

### DIFF
--- a/source/assets/scripts/collection-controller.js
+++ b/source/assets/scripts/collection-controller.js
@@ -58,4 +58,14 @@ window.addCardToCollection = function(card) {
     collection.push(card);
     localStorage.setItem(COLLECTION_KEY, JSON.stringify(collection));
   }
-} 
+}
+
+// On initial load, hide prev/next buttons if collection is visible
+window.addEventListener('DOMContentLoaded', () => {
+  const collectionVisible =
+    document.querySelector('pokemon-collection').style.display !== 'none';
+  if (collectionVisible) {
+    document.getElementById('turnPageLeft').style.display = 'none';
+    document.getElementById('turnPageRight').style.display = 'none';
+  }
+}); 

--- a/source/style.css
+++ b/source/style.css
@@ -317,26 +317,26 @@ button:active {
   filter: brightness(0.8);
 }
 .pokeball-toggle {
-  background: radial-gradient(circle at 50% 60%, #fff 60%, #ffcb05 100%);
+  background: #fff;
   border: 4px solid #222;
   border-radius: 50%;
   box-shadow: 0 2px 8px #2225;
   display: inline-block;
-  height: 40px;
+  height: 42px;
   overflow: visible;
   position: relative;
   transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
-  width: 40px;
+  width: 42px;
 }
 .pokeball-toggle::before {
   background: #ee1515;
-  border-bottom-left-radius: 50% 100%;
-  border-bottom-right-radius: 50% 100%;
+  border-top-left-radius: 50% 100%;
+  border-top-right-radius: 50% 100%;
   content: '';
   height: 50%;
   left: 0;
   position: absolute;
-  top: 50%;
+  top: 0;
   transition: background 0.3s;
   width: 100%;
   z-index: 1;


### PR DESCRIPTION
## 📌 Summary

- [x] Bugfix  
- [ ] Feature  
- [ ] Refactor  
- [ ] Documentation  
- [ ] Other (explain below)

---

## ✅ Changes

- Fixed pokeball now its not inverted
- Adjusted Pokeball height/width to fit the nav bar
- Fixed prev/next buttons bug in collection view. now on refresh and load it doesnt show buttons anymore


---

## 🔍 Checklist

- [x] My code follows the style guidelines
- [x] I have self-reviewed my own code
- [ ] I’ve tested my changes locally
- [ ] I’ve added relevant tests
- [ ] I’ve updated docs/comments as needed 
- [ ] Did I assign the correct people to this issue?

---


