### PR TITLE
Clickable binder slots

### DIFF
--- a/source/assets/scripts/assign-card-modal.js
+++ b/source/assets/scripts/assign-card-modal.js
@@ -134,7 +134,13 @@ export function showAssignCardModal(pageIndex, slotIndex) {
         slot: slotIndex,
       };
       // Persist changes
-      localStorage.setItem(COLLECTION_STORAGE_KEY, JSON.stringify(collection));
+        localStorage.setItem(COLLECTION_STORAGE_KEY, JSON.stringify(collection));
+      
+        const binder = document.querySelector("pokemon-binder");
+        if (binder) {
+            binder.setPages(collection);
+        }
+
       // Close modal
       document.getElementById('assign-card-modal')?.remove();
     }

--- a/source/assets/scripts/binder-controller.js
+++ b/source/assets/scripts/binder-controller.js
@@ -27,10 +27,7 @@ function updateBinder() {
 /**
  * Tells the binder component to flip forward two pages.
  */
-import { showAssignCardModal } from "./assign-card-modal.js";
 function turnPageRight() {
-  showAssignCardModal(1,5);
-  showAddCardModal
   const binder = document.querySelector("pokemon-binder");
   if (binder) {
     binder.flipForward();


### PR DESCRIPTION
## 📌 Made empty binder slots clickable, opening a modal to choose the card for that slot

> Briefly describe what this PR does and why.
Issues linked: #74

- [ ] Bugfix  
- [x] Feature  
- [ ] Refactor  
- [ ] Documentation  
- [ ] Other (explain below)

---

## ✅ Changes

Created a modal isolated in its own js file. Slight modifications to the slots in the binder file to add hooks for the modal. 
