### PR TITLE
Add card modal takes name/id, remove card from collection, card info

### DIFF
--- a/source/assets/scripts/addCardModal.js
+++ b/source/assets/scripts/addCardModal.js
@@ -63,7 +63,7 @@ export function showAddCardModal() {
   confirmBtn.addEventListener('click', () => {
     if (selectedCard && selectedCard.images?.small) {
       const COLLECTION_KEY = 'pokemonCollection';
-      const cardData = { name: selectedCard.name, imgUrl: selectedCard.images.small };
+      const cardData = { name: selectedCard.name, imgUrl: selectedCard.images.small, id: selectedCard.id };
 
       // Save to localStorage
       let collection = JSON.parse(localStorage.getItem(COLLECTION_KEY)) || [];

--- a/source/assets/scripts/binder-controller.js
+++ b/source/assets/scripts/binder-controller.js
@@ -2,6 +2,7 @@
 
 import "../../components/binder/pokemon-binder.js";
 
+
 /**
  * Reads the flat collection array from localStorage (key: "pokemonCollection"),
  * parses it, and hands it to <pokemon-binder> to re-render.

--- a/source/assets/scripts/collection-controller.js
+++ b/source/assets/scripts/collection-controller.js
@@ -66,7 +66,11 @@ document.getElementById('navBinder').addEventListener('click', e => {
 window.addCardToCollection = function(card) {
   const collection = document.querySelector("pokemon-collection").getCollection();
   if (!collection.some(c => c.imgUrl === card.imgUrl)) {
-    collection.push(card);
+    collection.push({
+      id: card.id,
+      name: card.name,
+      imgUrl: card.images.small
+    });
     localStorage.setItem(COLLECTION_KEY, JSON.stringify(collection));
   }
 }

--- a/source/components/collection/collection-view.js
+++ b/source/components/collection/collection-view.js
@@ -185,9 +185,12 @@ class PokemonCollection extends HTMLElement {
       try {
         const collection = this.getCollection();
         const cardMatch = collection.find(c => c.imgUrl === imgSrc);
-        if (cardMatch?.name) {
-          const results = await getCardsByName(cardMatch.name);
-          fullCard = results.find(c => c.images?.small === imgSrc || c.name === cardMatch.name);
+
+        const { getCardById } = await import('../../demos/api-search/api/pokemonAPI.js');
+        
+        if (cardMatch?.id) {
+          fullCard = await getCardById(cardMatch.id);
+        
         }
       } catch (err) {
         console.error('Error fetching card data for modal:', err);


### PR DESCRIPTION
## 📌 Summary

> Briefly describe what this PR does and why.
Issues linked: 

- [ x ] Bugfix  
- [ ] Feature  
- [ x ] Refactor  
- [ ] Documentation  
- [ x ] Other (explain below)

---

## ✅ Changes

> List key changes in this PR.

- Add card button in collection takes pokemon name or name AND id
- clicking on card image brings up modal
- modal has card info and remove card from collection functionality

---

## 📷 Screenshots (if UI)

> Include before/after screenshots or videos if applicable
![pokemonCardInfo](https://github.com/user-attachments/assets/93e15170-0f4a-4ee0-9710-7754321f4b31)


---

## 🔍 Checklist

- [ x ] My code follows the style guidelines
- [ x ] I have self-reviewed my own code
- [ x ] I’ve tested my changes locally
- [ ] I’ve added relevant tests
- [ x ] I’ve updated docs/comments as needed
- [ ] Did I assign the correct people to this issue?

---

## 🙋 Additional Notes

> Anything else reviewers should be aware of?
Card info functionality will not work with cards added previously. Cards in localstorage now have an additional field for id

---

